### PR TITLE
Change how getting DMed about username length

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ app.action("join-cult-of-threes", async ({ ack, body, client }) => {
   }
 });
 
-app.event("user_change", async ({ event }) => {
+app.event("user_profile_change", async ({ event }) => {
   const username = event.user.profile?.display_name!;
 
   if (username.length <= 3) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,13 @@ app.action("join-cult-of-threes", async ({ ack, body, client }) => {
 app.event("user_profile_change", async ({ event }) => {
   const username = event.user.profile?.display_name!;
 
-  if (username.length <= 3) {
+  const members = membersCache.get<string[]>("members");
+
+  if (!members) {
+    throw new Error("Members cache is empty.");
+  }
+
+  if (username.length <= 3 && !members.includes(event.user.id)) {
     try {
       await app.client.chat.postMessage({
         token: process.env.SLACK_BOT_TOKEN,
@@ -90,12 +96,6 @@ app.event("user_profile_change", async ({ event }) => {
   }
 
   if (username.length > 3) {
-    const members = membersCache.get<string[]>("members");
-
-    if (!members) {
-      throw new Error("Members cache is empty.");
-    }
-
     if (members.includes(event.user.id)) {
       try {
         const result = await app.client.conversations.kick({


### PR DESCRIPTION
With the current implementation, a user will get notified of joining the club if their display name has been changed to have 3 or less characters. 

However, the `user_change` event doesn't just activate on a user changing their profile ([`user_profile_changed`](https://api.slack.com/events/user_profile_changed)), it also activates when their huddle status is updated ([`user_huddle_changed`](https://api.slack.com/events/user_huddle_changed)) or when their status is updated ([`user_status_changed`](https://api.slack.com/events/user_status_changed)).

This PR changes the event listener to `user_profile_changed`, ensuring that the message is only sent when a user changes their profile. It also makes a check for whether the user is in the member cache before sending the message.

For this PR to be accepted, `user_change` needs to be changed to `user_profile_changed` in the Slack API dashboard.